### PR TITLE
Provide compatibility with Pillow

### DIFF
--- a/lump.py
+++ b/lump.py
@@ -164,10 +164,23 @@ class Graphic(Lump):
     def to_Image(self):
         """Convert to a PIL Image instance"""
         im = Image.new('P', self.dimensions, None)
-        if isinstance(self, Flat):
-            im.fromstring(self.data)
-        else:
-            im.fromstring(self.to_raw())
+        try:
+            if isinstance(self, Flat):
+                im.frombytes(self.data)
+            else:
+                im.frombytes(self.to_raw())
+        except AttributeError as ex:
+            # Provide compatibility with old PIL that has fromstring() method
+            # instead of frombytes() method in Image class.
+            if str(ex) == "frombytes":
+                # frombytes() method is indeed missing in Image class
+                if isinstance(self, Flat):
+                    im.fromstring(self.data)
+                else:
+                    im.fromstring(self.to_raw())
+            else:
+                # Another attribute is missing, re-raising the error
+                raise
         im.putpalette(self.palette.save_bytes)
         return im
 


### PR DESCRIPTION
PIL seems to be no longer maintained.

Modern linux distributions have Pillow package (fork of PIL) instead of
PIL package in their repositories.

But Omgifol is no longer working with the recent versions of Pillow,
because "fromstring()" method of it's "Image" class was deprecated and
eventually removed. Each time Omgifol tries to use "fromstring()" method
Pillow fails with this error:
"NotImplementedError: fromstring() has been removed. Please call
frombytes() instead."
On some older versions of Pillow this error has "Exception" type.

This patch solves this problem by making Omgifol use "frombytes()"
method of Pillow's "Image" class instead of using deprecated
"fromstring()" method. Also it provides compatibility with the old
original PIL library.
